### PR TITLE
Form should support Enter inside inputs

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -20,7 +20,9 @@ class Form extends Component {
         });
     }
 
-    submitForm = () => {
+    onFormSubmit = (event) => {
+        event.preventDefault();
+        
         this.props.handleSubmit(this.state);
         this.setState(this.initialState);
     }
@@ -29,7 +31,7 @@ class Form extends Component {
         const { name, job } = this.state; 
 
         return (
-            <form>
+            <form onSubmit={this.onFormSubmit}>
                 <label>Name</label>
                 <input 
                     type="text" 
@@ -41,11 +43,10 @@ class Form extends Component {
                     type="text" 
                     name="job" 
                     value={job} 
-                    onChange={this.handleChange}/>
-                <input 
-                    type="button" 
-                    value="Submit" 
-                    onClick={this.submitForm} />
+                    onChange={this.handleChange} />
+                <button type="submit">
+                    Submit
+                </button>
             </form>
         );
     }


### PR DESCRIPTION
It's a best practice to hook to the form onSubmit instead of onClick on the button.  
That way Enter is automatically supported in the inputs (which is good for UX).  
And then we can use a normal `<button>` element as well (cleaner).